### PR TITLE
Allow overriding type and desc in tree thaw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .\#*
 .build
 .tidyall.d
-.tidyallrc
 /t/test-data/GeoLite2-Country.json
 Build
 Debian_CPANTS.txt

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,0 +1,4 @@
+[PerlTidy]
+select = **/*.{pl,pm,t,psgi}
+ignore = blib/**/*
+argv = --profile=$ROOT/.perltidyallrc

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,4 +1,5 @@
 [PerlTidy]
 select = **/*.{pl,pm,t,psgi}
 ignore = blib/**/*
+ignore = inc/**/*
 argv = --profile=$ROOT/.perltidyallrc

--- a/lib/MaxMind/DB/Writer/Serializer.pm
+++ b/lib/MaxMind/DB/Writer/Serializer.pm
@@ -236,7 +236,8 @@ sub _encode_pointer {
 
     $self->_require_x_bits_unsigned_integer( 32, $value );
 
-    my $ctrl_byte = ord( $self->_control_bytes( $TypeNameToNum{pointer}, 0 ) );
+    my $ctrl_byte
+        = ord( $self->_control_bytes( $TypeNameToNum{pointer}, 0 ) );
 
     my @value_bytes;
     for my $n ( 0 .. 3 ) {
@@ -381,7 +382,9 @@ sub _encode_int32 {
     $encoded_value =~ s/^\x00+//;
 
     $self->_write_encoded_data(
-        $self->_control_bytes( $TypeNameToNum{int32}, length($encoded_value) ),
+        $self->_control_bytes(
+            $TypeNameToNum{int32}, length($encoded_value)
+        ),
         $encoded_value,
     );
 }

--- a/lib/MaxMind/DB/Writer/Tree.pm
+++ b/lib/MaxMind/DB/Writer/Tree.pm
@@ -268,13 +268,14 @@ sub write_tree {
 
 sub new_from_frozen_tree {
     my $class = shift;
-    my ( $filename, $callback, $database_type, $description ) = validated_list(
+    my ( $filename, $callback, $database_type, $description )
+        = validated_list(
         \@_,
         filename              => { isa => 'Str' },
         map_key_type_callback => { isa => 'CodeRef' },
-        database_type => {isa => 'Str', optional => 1},
-        description => {isa => 'HashRef[Str]', optional => 1},
-    );
+        database_type         => { isa => 'Str', optional => 1 },
+        description           => { isa => 'HashRef[Str]', optional => 1 },
+        );
 
     open my $fh, '<:raw', $filename;
     my $packed_params_size;
@@ -290,7 +291,7 @@ sub new_from_frozen_tree {
     my $params = decode_sereal($frozen_params);
 
     $params->{database_type} = $database_type if defined $database_type;
-    $params->{description} = $description if defined $description;
+    $params->{description}   = $description   if defined $description;
 
     my $tree = _thaw_tree(
         $filename,

--- a/lib/MaxMind/DB/Writer/Tree.pm
+++ b/lib/MaxMind/DB/Writer/Tree.pm
@@ -268,10 +268,12 @@ sub write_tree {
 
 sub new_from_frozen_tree {
     my $class = shift;
-    my ( $filename, $callback ) = validated_list(
+    my ( $filename, $callback, $database_type, $description ) = validated_list(
         \@_,
         filename              => { isa => 'Str' },
         map_key_type_callback => { isa => 'CodeRef' },
+        database_type => {isa => 'Str', optional => 1},
+        description => {isa => 'HashRef[Str]', optional => 1},
     );
 
     open my $fh, '<:raw', $filename;
@@ -286,6 +288,9 @@ sub new_from_frozen_tree {
         die "Could not read $params_size bytes from $filename: $!";
     }
     my $params = decode_sereal($frozen_params);
+
+    $params->{database_type} = $database_type if defined $database_type;
+    $params->{description} = $description if defined $description;
 
     my $tree = _thaw_tree(
         $filename,
@@ -567,13 +572,15 @@ their corresponding IPv4 ranges when the tree is written to disk.
 
 This method constructs a tree from a file containing a frozen tree.
 
-This method require the following two parameters:
+This method accepts the following parameters:
 
 =over 4
 
 =item * filename
 
 The filename containing the frozen tree.
+
+This parameter is required.
 
 =item * map_key_type_callback
 
@@ -583,6 +590,22 @@ more details.
 
 This needs to be passed because subroutine references cannot be reliably
 serialized and restored between processes.
+
+This parameter is required.
+
+=item * database_type
+
+Override the C<<database_type>> of the frozen tree. This accepts a string of
+the same form as the C<<new()>> constructor.
+
+This parameter is optional.
+
+=item * description
+
+Override the C<<description>> of the frozen tree. This accepts a hashref of
+the same form as the C<<new()>> constructor.
+
+This parameter is optional.
 
 =back
 

--- a/t/MaxMind/DB/Writer/Serializer-large-pointer.t
+++ b/t/MaxMind/DB/Writer/Serializer-large-pointer.t
@@ -21,12 +21,14 @@ while ( length ${ $serializer->buffer() } < $four_byte_pointer_threshold ) {
 }
 
 $MaxMind::DB::Writer::Serializer::DEBUG = 1;
-my $small_pointer = $serializer->store_data( utf8_string => $first_short_string );
+my $small_pointer
+    = $serializer->store_data( utf8_string => $first_short_string );
 
 my $last_short_string = 'another short string';
 
 $serializer->store_data( utf8_string => $last_short_string );
-my $large_pointer = $serializer->store_data( utf8_string => $last_short_string );
+my $large_pointer
+    = $serializer->store_data( utf8_string => $last_short_string );
 
 my $buffer = $serializer->buffer();
 open my $fh, '<:raw', $buffer;

--- a/t/MaxMind/DB/Writer/Serializer-types/utf8_string.t
+++ b/t/MaxMind/DB/Writer/Serializer-types/utf8_string.t
@@ -18,7 +18,6 @@ use Test::More;
         $tb->todo_output();
 }
 
-
 test_encoding_of_type( utf8_string => test_cases_for('utf8_string') );
 
 my $max_size = ( 2**24 - 1 ) + 65821;
@@ -43,7 +42,7 @@ _test_long_string(
 done_testing();
 
 sub _test_long_string {
-    my $length = shift;
+    my $length  = shift;
     my $first_4 = shift;
 
     my $serializer = MaxMind::DB::Writer::Serializer->new(

--- a/t/MaxMind/DB/Writer/Tree-freeze-thaw.t
+++ b/t/MaxMind/DB/Writer/Tree-freeze-thaw.t
@@ -10,7 +10,11 @@ use Test::Requires {
     'MaxMind::DB::Reader' => 0.040000,
 };
 
-use Test::MaxMind::DB::Writer qw( make_tree_from_pairs test_freeze_thaw );
+use Test::MaxMind::DB::Writer qw(
+    make_tree_from_pairs
+    test_freeze_thaw
+    test_freeze_thaw_optional_params
+);
 use Test::More;
 
 use File::Temp qw( tempdir );
@@ -47,6 +51,7 @@ for my $record_size ( 24, 28, 32 ) {
             "Tree with $count networks - IPv4 only - $record_size-bit records",
             sub {
                 test_freeze_thaw($tree);
+                test_freeze_thaw_optional_params($tree);
             }
         );
 

--- a/t/MaxMind/DB/Writer/Tree-output/record-deduplication.t
+++ b/t/MaxMind/DB/Writer/Tree-output/record-deduplication.t
@@ -60,6 +60,7 @@ my $calls = 0;
         # We want to track calls to this method made from tree.c (not internal
         # recursive calls).
         if ( ( caller(0) )[0] ne __PACKAGE__ ) {
+
             # There's always one call to store the metadata
             $calls++
                 unless $_[1]->{build_epoch};

--- a/t/MaxMind/DB/Writer/Tree-output/verifies.t
+++ b/t/MaxMind/DB/Writer/Tree-output/verifies.t
@@ -32,8 +32,7 @@ for my $record_size ( 24, 28, 32 ) {
 
 for my $record_size ( 24, 28, 32 ) {
     for my $should_alias ( 0, 1 ) {
-        my $file
-            = "$tempdir/IPv6-$record_size-alias-$should_alias.mmdb";
+        my $file = "$tempdir/IPv6-$record_size-alias-$should_alias.mmdb";
 
         _write_tree(
             $record_size,
@@ -52,8 +51,7 @@ for my $record_size ( 24, 28, 32 ) {
             $file,
         );
 
-        my $desc
-            = "IPv6 - $record_size-bit record - alias: $should_alias";
+        my $desc = "IPv6 - $record_size-bit record - alias: $should_alias";
         _verify( $file, $desc );
     }
 }

--- a/t/lib/Test/MaxMind/DB/Writer.pm
+++ b/t/lib/Test/MaxMind/DB/Writer.pm
@@ -251,11 +251,11 @@ sub test_freeze_thaw_optional_params {
         database_type         => $type,
     );
 
-    is_deeply(
+    is(
         $tree2->database_type, $type,
         'type passed to constructor overrides frozen type'
     );
-    is(
+    is_deeply(
         $tree2->description, $description,
         'description passed to constructor overrides frozen description'
     );

--- a/t/lib/Test/MaxMind/DB/Writer.pm
+++ b/t/lib/Test/MaxMind/DB/Writer.pm
@@ -19,6 +19,7 @@ our @EXPORT_OK = qw(
     ranges_to_data
     test_iterator_sanity
     test_freeze_thaw
+    test_freeze_thaw_optional_params
     test_tree
 );
 
@@ -232,6 +233,32 @@ sub test_freeze_thaw {
     }
 
     return ( $tree1, $tree2 );
+}
+
+sub test_freeze_thaw_optional_params {
+    my $tree1 = shift;
+
+    my $dir = tempdir( CLEANUP => 1 );
+    my $file = "$dir/frozen-tree-params";
+    $tree1->freeze_tree($file);
+
+    my $description = { en => 'A tree in the forest' };
+    my $type        = 'TreeDB';
+    my $tree2       = MaxMind::DB::Writer::Tree->new_from_frozen_tree(
+        filename              => $file,
+        map_key_type_callback => $tree1->map_key_type_callback(),
+        description           => $description,
+        database_type         => $type,
+    );
+
+    is_deeply(
+        $tree2->database_type, $type,
+        'type passed to constructor overrides frozen type'
+    );
+    is(
+        $tree2->description, $description,
+        'description passed to constructor overrides frozen description'
+    );
 }
 
 1;

--- a/t/lib/Test/MaxMind/DB/Writer/Serializer.pm
+++ b/t/lib/Test/MaxMind/DB/Writer/Serializer.pm
@@ -23,7 +23,7 @@ sub test_encoding_of_type {
     while ( my ( $input, $expect ) = $iter->() ) {
         my $desc = "packed $type - ";
 
-        if ( ref $input && ! blessed $input ) {
+        if ( ref $input && !blessed $input ) {
             $desc .=
                 ref $input eq 'HASH'
                 ? 'hash with ' . ( scalar keys %{$input} ) . ' keys'
@@ -80,7 +80,7 @@ my %metadata_keys = (
 );
 
 sub _map_key_type {
-    my $key  = shift;
+    my $key = shift;
 
     # locale id
     return 'utf8_string' if $key =~ /^[a-z]{2,3}(?:-[A-Z]{2})?$/;


### PR DESCRIPTION
This is necessary as we want to be able to upgrade a database from
one type to another by adding additional data.