### PR TITLE
Fix several memory leaks in tree code

### DIFF
--- a/c/tree.c
+++ b/c/tree.c
@@ -948,6 +948,8 @@ MMDBW_tree_s *thaw_tree(char *filename, uint32_t initial_offset,
         insert_record_for_network(tree, thawed->network, thawed->record,
                                   tree->merge_record_collisions);
         free_network(thawed->network);
+        free(thawed->network);
+        free(thawed->record);
         free(thawed);
     }
 

--- a/c/tree.c
+++ b/c/tree.c
@@ -1022,7 +1022,7 @@ LOCAL thawed_network_s *thaw_network(MMDBW_tree_s *tree, uint8_t **buffer)
         bytes = checked_malloc(4);
         memcpy(bytes, start_ip_bytes + 12, 4);
     } else {
-        bytes = checked_malloc(4);
+        bytes = checked_malloc(16);
         memcpy(bytes, &start_ip, 16);
     }
 


### PR DESCRIPTION
A couple of these were found with Valgrind, and the rest from code
review. I have not yet closely reviewed all of the reference counts
for the Perl data types.