### PR TITLE
Move only if parent exists to a merge strategy. Deprecate things.

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,9 +4,10 @@
 - An add-only-if-parent-exists merge strategy was added. This replaces the
   functionality of insert_only_if_parent_exists.
 - Deprecated insert_only_if_parent_exists and force_overwrite insertion
-  arguments. These arguments will now warn and will be removed in the future.
+  arguments. These arguments will now warn and will be removed in a future
+  major release.
 - Deprecated merge_record_collisions constructor argument. This argument will
-  now warn and will be removed in the future.
+  now warn and will be removed in a future major release.
 
 
 0.200004 2016-04-20

--- a/Changes
+++ b/Changes
@@ -1,5 +1,14 @@
 {{$NEXT}}
 
+- The insertion methods now take a merge_strategy argument.
+- An add-only-if-parent-exists merge strategy was added. This replaces the
+  functionality of insert_only_if_parent_exists.
+- Deprecated insert_only_if_parent_exists and force_overwrite insertion
+  arguments. These arguments will now warn and will be removed in the future.
+- Deprecated merge_record_collisions constructor argument. This argument will
+  now warn and will be removed in the future.
+
+
 0.200004 2016-04-20
 
 - Added the optional tree insertion argument insert_only_if_parent_exists.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MaxMind::DB::Writer - Create MaxMind DB database files
 
 # VERSION
 
-version 0.200004
+version 0.200005
 
 # SYNOPSIS
 

--- a/c/tree.h
+++ b/c/tree.h
@@ -64,16 +64,12 @@ typedef enum {
 } MMDBW_record_type;
 
 typedef enum {
+    MMDBW_MERGE_STRATEGY_UNKNOWN,
     MMDBW_MERGE_STRATEGY_NONE,
     MMDBW_MERGE_STRATEGY_TOPLEVEL,
-    MMDBW_MERGE_STRATEGY_RECURSE
+    MMDBW_MERGE_STRATEGY_RECURSE,
+    MMDBW_MERGE_STRATEGY_ADD_ONLY_IF_PARENT_EXISTS
 } MMDBW_merge_strategy;
-
-typedef enum {
-    MMDBW_INSERTION_TYPE_DEFAULT,
-    MMDBW_INSERTION_TYPE_FORCE_OVERWRITE,
-    MMDBW_INSERTION_TYPE_ONLY_IF_PARENT_EXISTS,
-} MMDBW_insertion_type;
 
 typedef struct MMDBW_record_s {
     union {
@@ -124,15 +120,15 @@ typedef void (MMDBW_iterator_callback)(MMDBW_tree_s *tree,
                                   const bool alias_ipv6);
     extern void insert_network(MMDBW_tree_s *tree, const char *ipstr,
                                const uint8_t prefix_length, SV *key_sv, SV *data,
-                               MMDBW_insertion_type insertion_type);
+                               MMDBW_merge_strategy merge_strategy);
     extern void insert_range(MMDBW_tree_s *tree, const char *start_ipstr,
                              const char *end_ipstr, SV *key_sv, SV *data_sv,
-                             MMDBW_insertion_type insertion_type);
+                             MMDBW_merge_strategy merge_strategy);
     extern void remove_network(MMDBW_tree_s *tree, const char *ipstr,
                                const uint8_t prefix_length);
     extern SV *merge_hashes_for_keys(MMDBW_tree_s *tree, const char *const key_from,
                                      const char *const key_into, MMDBW_network_s *network,
-                                     bool merge_only_if_parent_exists);
+                                     MMDBW_merge_strategy merge_strategy);
     extern SV *lookup_ip_address(MMDBW_tree_s *tree, const char *const ipstr);
     extern MMDBW_node_s *new_node();
     extern void assign_node_numbers(MMDBW_tree_s *tree);

--- a/lib/MaxMind/DB/Writer/Tree.xs
+++ b/lib/MaxMind/DB/Writer/Tree.xs
@@ -141,14 +141,6 @@ SV *maybe_method(HV *package, const char *const method)
     return NULL;
 }
 
-MMDBW_insertion_type insertion_type(bool force_overwrite,
-                                    bool only_if_parent_exists)
-{
-    return force_overwrite ? MMDBW_INSERTION_TYPE_FORCE_OVERWRITE :
-           only_if_parent_exists ? MMDBW_INSERTION_TYPE_ONLY_IF_PARENT_EXISTS :
-           MMDBW_INSERTION_TYPE_DEFAULT;
-}
-
 /* *INDENT-OFF* */
 
 /* XXX - it'd be nice to find a way to get the tree from the XS code so we
@@ -176,30 +168,29 @@ _create_tree(ip_version, record_size, merge_strategy, alias_ipv6)
         RETVAL
 
 void
-_insert_network(self, ip_address, prefix_length, key, data, force_overwrite, only_if_parent_exists)
+_insert_network(self, ip_address, prefix_length, key, data, merge_strategy)
     SV *self;
     char *ip_address;
     uint8_t prefix_length;
     SV *key;
     SV *data;
-    bool force_overwrite;
-    bool only_if_parent_exists;
+    MMDBW_merge_strategy merge_strategy;
 
     CODE:
-        insert_network(tree_from_self(self), ip_address, prefix_length, key, data, insertion_type(force_overwrite, only_if_parent_exists));
+        MMDBW_tree_s *tree = tree_from_self(self);
+        insert_network(tree, ip_address, prefix_length, key, data, merge_strategy);
 
 void
-_insert_range(self, start_ip_address, end_ip_address, key, data, force_overwrite, only_if_parent_exists)
+_insert_range(self, start_ip_address, end_ip_address, key, data, merge_strategy)
     SV *self;
     char *start_ip_address;
     char *end_ip_address;
     SV *key;
     SV *data;
-    bool force_overwrite;
-    bool only_if_parent_exists;
+    MMDBW_merge_strategy merge_strategy;
 
     CODE:
-        insert_range(tree_from_self(self), start_ip_address, end_ip_address, key, data, insertion_type(force_overwrite, only_if_parent_exists));
+        insert_range(tree_from_self(self), start_ip_address, end_ip_address, key, data, merge_strategy);
 
 void
 _remove_network(self, ip_address, prefix_length)
@@ -303,7 +294,7 @@ _thaw_tree(filename, initial_offset, ip_version, record_size, merge_strategy, al
     bool alias_ipv6;
 
     CODE:
-    RETVAL = thaw_tree(filename, initial_offset, ip_version, record_size, merge_strategy, alias_ipv6);
+        RETVAL = thaw_tree(filename, initial_offset, ip_version, record_size, merge_strategy, alias_ipv6);
 
     OUTPUT:
         RETVAL

--- a/lib/MaxMind/DB/Writer/typemap
+++ b/lib/MaxMind/DB/Writer/typemap
@@ -1,12 +1,15 @@
 TYPEMAP
-MMDBW_tree_s *     T_OPAQUE
-uint8_t            T_UV
-uint32_t           T_UV
-MMDBW_merge_strategy  MMDBW_MERGE_STRATEGY_T
+MMDBW_tree_s *       T_OPAQUE
+uint8_t              T_UV
+uint32_t             T_UV
+MMDBW_merge_strategy MMDBW_MERGE_STRATEGY_T
 
 INPUT
 MMDBW_MERGE_STRATEGY_T
     char* sv_text = SvPV_nolen($arg);
     $var = !strcmp(sv_text, \"toplevel\") ? MMDBW_MERGE_STRATEGY_TOPLEVEL
-           :  !strcmp(sv_text, \"recurse\") ? MMDBW_MERGE_STRATEGY_RECURSE
-           : MMDBW_MERGE_STRATEGY_NONE;
+           : !strcmp(sv_text, \"recurse\") ? MMDBW_MERGE_STRATEGY_RECURSE
+           : !strcmp(sv_text, \"add-only-if-parent-exists\") ?
+             MMDBW_MERGE_STRATEGY_ADD_ONLY_IF_PARENT_EXISTS
+           : !strcmp(sv_text, \"none\") ? MMDBW_MERGE_STRATEGY_NONE
+           : MMDBW_MERGE_STRATEGY_UNKNOWN;

--- a/perlcriticrc
+++ b/perlcriticrc
@@ -82,3 +82,6 @@ add_packages = Test::Builder
 
 # "use v5.14" is more readable than "use 5.014"
 [-ValuesAndExpressions::ProhibitVersionStrings]
+
+[-Subroutines::ProhibitExplicitReturnUndef]
+

--- a/t/MaxMind/DB/Writer/Tree-data-references.t
+++ b/t/MaxMind/DB/Writer/Tree-data-references.t
@@ -11,7 +11,7 @@ subtest 'Reference counting when replacing node, no merging' => sub {
 };
 
 subtest 'Reference counting with merging' => sub {
-    _test_insert( merge_record_collisions => 1 );
+    _test_insert( merge_strategy => 'toplevel' );
 };
 
 sub _test_insert {

--- a/t/MaxMind/DB/Writer/Tree-freeze-thaw.t
+++ b/t/MaxMind/DB/Writer/Tree-freeze-thaw.t
@@ -32,7 +32,7 @@ for my $record_size ( 24, 28, 32 ) {
             database_type           => 'Test',
             languages               => [ 'en', 'fr' ],
             description             => { en => 'Test tree' },
-            merge_record_collisions => 1,
+            merge_strategy => 'toplevel',
             map_key_type_callback   => sub { 'uint32' },
             remove_reserved_networks => 0,
         );
@@ -69,7 +69,7 @@ for my $record_size ( 24, 28, 32 ) {
                 database_type           => 'Test',
                 languages               => ['en'],
                 description             => { en => 'Test tree' },
-                merge_record_collisions => 1,
+                merge_strategy => 'toplevel',
                 map_key_type_callback   => $cb,
                 remove_reserved_networks => 0,
             );
@@ -166,7 +166,7 @@ for my $record_size ( 24, 28, 32 ) {
         database_type           => 'Test',
         languages               => ['en'],
         description             => { en => 'Test tree' },
-        merge_record_collisions => 1,
+        merge_strategy => 'toplevel',
         map_key_type_callback   => sub {'uint32'},
         remove_reserved_networks => 0,
     );

--- a/t/MaxMind/DB/Writer/Tree-thaw-merge.t
+++ b/t/MaxMind/DB/Writer/Tree-thaw-merge.t
@@ -100,10 +100,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            !$args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'none',
             'thawed merge_strategy'
@@ -127,15 +123,11 @@ check_tree(
 
 check_tree(
     'check no merging explictly',
-    [ merge_record_collisions => 0 ],
+    [ merge_strategy => 'none' ],
     [],
     sub {
         my %args = @_;
 
-        ok(
-            !$args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'none',
             'thawed merge_strategy'
@@ -159,15 +151,11 @@ check_tree(
 
 check_tree(
     'check no merging and none explictly',
-    [ merge_record_collisions => 0, merge_strategy => 'none' ],
+    [ merge_strategy => 'none' ],
     [],
     sub {
         my %args = @_;
 
-        ok(
-            !$args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'none',
             'thawed merge_strategy'
@@ -195,15 +183,11 @@ check_tree(
 
 check_tree(
     'set mrc in constructor, toplevel in thaw',
-    [ merge_record_collisions => 1 ],
-    [ merge_strategy          => 'toplevel' ],
+    [ merge_strategy => 'toplevel' ],
+    [ merge_strategy => 'toplevel' ],
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -234,10 +218,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -268,10 +248,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'recurse',
             'thawed merge_strategy'
@@ -301,15 +277,11 @@ check_tree(
 
 check_tree(
     'set mrc only in constructor',
-    [ merge_record_collisions => 1 ],
+    [ merge_strategy => 'toplevel' ],
     [],
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -340,10 +312,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -374,10 +342,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'recurse',
             'thawed merge_strategy'
@@ -412,10 +376,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -440,15 +400,11 @@ check_tree(
 
 check_tree(
     'set mrc off in constructor, toplevel in thaw',
-    [ merge_record_collisions => 0 ],
-    [ merge_strategy          => 'toplevel' ],
+    [ merge_strategy => 'none' ],
+    [ merge_strategy => 'toplevel' ],
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -478,10 +434,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',
             'thawed merge_strategy'
@@ -511,10 +463,6 @@ check_tree(
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'recurse',
             'thawed merge_strategy'
@@ -539,15 +487,11 @@ check_tree(
 
 check_tree(
     'set mrc off in constructor, recurse in thaw',
-    [ merge_record_collisions => 0 ],
-    [ merge_strategy          => 'recurse' ],
+    [ merge_strategy => 'none' ],
+    [ merge_strategy => 'recurse' ],
     sub {
         my %args = @_;
 
-        ok(
-            $args{thawed_tree}->merge_record_collisions,
-            'thawed merge_record_collisons'
-        );
         is(
             $args{thawed_tree}->merge_strategy, 'recurse',
             'thawed merge_strategy'

--- a/t/MaxMind/DB/Writer/Tree-thaw-merge.t
+++ b/t/MaxMind/DB/Writer/Tree-thaw-merge.t
@@ -10,11 +10,11 @@ use Test::Requires {
     'MaxMind::DB::Reader' => 0.040000,
 };
 
-use Test::More;
-
 use File::Temp qw( tempdir );
 use MaxMind::DB::Writer::Tree;
 use Net::Works::Network;
+use Test::More;
+use Test::Warnings qw( :all );
 
 ########################################################################
 # the purpose of this test is to check the merging arguments are being
@@ -99,6 +99,17 @@ check_tree(
     [],
     sub {
         my %args = @_;
+
+        like(
+            warning {
+                ok(
+                    !$args{thawed_tree}->merge_record_collisions,
+                    'thawed merge_record_collisons'
+                    )
+            },
+            qr/merge_record_collisions is deprecated/,
+            'received deprecation message'
+        );
 
         is(
             $args{thawed_tree}->merge_strategy, 'none',
@@ -187,6 +198,17 @@ check_tree(
     [ merge_strategy => 'toplevel' ],
     sub {
         my %args = @_;
+
+        like(
+            warning {
+                ok(
+                    $args{thawed_tree}->merge_record_collisions,
+                    'thawed merge_record_collisons'
+                    )
+            },
+            qr/merge_record_collisions is deprecated/,
+            'received deprecation message'
+        );
 
         is(
             $args{thawed_tree}->merge_strategy, 'toplevel',

--- a/t/MaxMind/DB/Writer/Tree.t
+++ b/t/MaxMind/DB/Writer/Tree.t
@@ -240,7 +240,7 @@ subtest 'Inserting invalid neworks and ranges' => sub {
         database_type           => 'Test',
         languages               => ['en'],
         description             => { en => 'Test tree' },
-        merge_record_collisions => 1,
+        merge_strategy => 'toplevel',
         map_key_type_callback   => sub { 'utf8_string' },
         alias_ipv6_to_ipv4      => 1,
     );
@@ -284,7 +284,7 @@ subtest 'Recording merging at /0' => sub {
         database_type           => 'Test',
         languages               => ['en'],
         description             => { en => 'Test tree' },
-        merge_record_collisions => 1,
+        merge_strategy => 'toplevel',
         map_key_type_callback   => sub { 'utf8_string' },
 
         # These are 0 to as enabling them will create more than one network


### PR DESCRIPTION
- The insertion methods now take a merge_strategy argument.
- An `add-only-if-parent-exists` merge strategy was added. This replaces the
  functionality of` insert_only_if_parent_exists`.
- Deprecated `insert_only_if_parent_exists` and `force_overwrite` insertion
  arguments. These arguments will now warn and will be removed in the future.
- Deprecated `merge_record_collisions` constructor argument. This argument will
  now warn and will be removed in the future.
