### PR TITLE
Fix compilation issues

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -8,3 +8,4 @@ Olaf Alders <oalders@maxmind.com> <olaf@wundersolutions.com>
 Ran Eilam <reilam@maxmind.com> <eilara@users.noreply.github.com>
 Ran Eilam <reilam@maxmind.com> <ran.eilam@gmail.com>
 Thomas J Mather <tjmather@maxmind.com> <tjmather@maxmind.com>
+William Storey <wstorey@maxmind.com> <will@summercat.com>

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Fixed compilation errors.
+
+
 0.300002 2018-06-06
 
 [ BUG FIXES ]

--- a/c/tree.h
+++ b/c/tree.h
@@ -1,10 +1,7 @@
 #include "EXTERN.h"
-// clang-format wants to change the order of these headers. However order is
-// important.
-// clang-format off
 #include "perl.h"
+// It is crucial that XSUB.h comes after perl.h.
 #include "XSUB.h"
-// clang-format on
 #include <stdbool.h>
 #include <stdint.h>
 #include <uthash.h>

--- a/c/tree.h
+++ b/c/tree.h
@@ -1,6 +1,10 @@
 #include "EXTERN.h"
-#include "XSUB.h"
+// clang-format wants to change the order of these headers. However order is
+// important.
+// clang-format off
 #include "perl.h"
+#include "XSUB.h"
+// clang-format on
 #include <stdbool.h>
 #include <stdint.h>
 #include <uthash.h>


### PR DESCRIPTION
Apparently the Perl XS header order is significant. clang-format changed this and caused issues.

I could not see much in the way of this being documented as required.

I am also not clear on why this built fine on Travis. I encountered issues building on both Ubuntu Bionic and Trusty in my testing prior to this fix. I used the OS packaged Perls though, so the environment is different compared to Travis.