### PR TITLE
Update method and parameter names in eg/freeze-thaw

### DIFF
--- a/eg/freeze-thaw
+++ b/eg/freeze-thaw
@@ -17,13 +17,13 @@ my $cb = sub {
 };
 
 my $tree = MaxMind::DB::Writer::Tree->new(
-    ip_version              => 6,
-    record_size             => 24,
-    database_type           => 'Test',
-    languages               => ['en'],
-    description             => { en => 'Test tree' },
-    merge_record_collisions => 1,
-    map_key_type_callback   => $cb,
+    ip_version            => 6,
+    record_size           => 24,
+    database_type         => 'Test',
+    languages             => ['en'],
+    description           => { en => 'Test tree' },
+    merge_strategy        => 'toplevel',
+    map_key_type_callback => $cb,
 );
 
 my $s = Timer::Simple->new( start => 1 );
@@ -59,7 +59,10 @@ $s->stop();
 print "Frozen tree to disk in ", $s->elapsed, " seconds\n";
 $s->start();
 
-my $tree2 = MaxMind::DB::Writer::Tree->from_frozen_tree( $file, $cb );
+my $tree2 = MaxMind::DB::Writer::Tree->new_from_frozen_tree(
+    filename              => $file,
+    map_key_type_callback => $cb,
+);
 
 $s->stop();
 print "Thawed tree in ", $s->elapsed, " seconds\n";


### PR DESCRIPTION
Running the script in `eg/freeze-thaw` resulted in a deprecation warning regarding the `merge_record_collisions` parameter to the tree constructor, and a crash when calling `from_frozen_tree`.

This patch fixes these by replacing the constructor parameter with `merge_strategy => 'toplevel'` and calling `new_from_frozen_tree` instead.