### PR TITLE
Provide format string to croak() calls

### DIFF
--- a/c/tree.c
+++ b/c/tree.c
@@ -439,7 +439,7 @@ void remove_network(MMDBW_tree_s *tree,
 
     free_network(&network);
     if (status != MMDBW_SUCCESS) {
-        croak(status_error_message(status));
+        croak("Unable to remove network: %s", status_error_message(status));
     }
 }
 
@@ -1612,7 +1612,7 @@ MMDBW_tree_s *thaw_tree(char *filename,
         free(thawed->record);
         free(thawed);
         if (status != MMDBW_SUCCESS) {
-            croak(status_error_message(status));
+            croak("Could not thaw tree: %s", status_error_message(status));
         }
     }
 


### PR DESCRIPTION
This tiny change resolves errors when building with -Werror=format-security (F29, perl v5.28.0, GCC 8.2.1)